### PR TITLE
Fix KB, chatbot, and AI runtime flows broken by upstream drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Set up project
     runs-on: ubuntu-latest
     outputs:
-      python-version: 3.9
+      python-version: "3.11"
 
     steps:
       - name: Checkout code
@@ -22,7 +22,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Cache Poetry
         uses: actions/cache@v3
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Cache Poetry
         uses: actions/cache@v3
@@ -106,7 +106,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Cache Poetry
         uses: actions/cache@v3

--- a/alembic/versions/a7f3e9c12b48_update_default_claude_to_sonnet_4_5.py
+++ b/alembic/versions/a7f3e9c12b48_update_default_claude_to_sonnet_4_5.py
@@ -1,0 +1,84 @@
+#
+# Copyright 2025 EDT&Partners
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""update_default_claude_to_sonnet_4_5
+
+The seeded default Anthropic model (Claude 3.7 Sonnet,
+anthropic.claude-3-7-sonnet-20250219-v1:0) no longer has an inference profile
+available in the deployment region, so every knowledge-base / chatbot call
+failed with ResourceNotFoundException. Point the default at Claude Sonnet 4.5,
+which is available as an inference profile (eu.anthropic.claude-sonnet-4-5-...).
+
+Revision ID: a7f3e9c12b48
+Revises: 6c9fc5098093
+Create Date: 2026-06-03 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a7f3e9c12b48'
+down_revision: Union[str, None] = '6c9fc5098093'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Repoint the default Anthropic model from the now-unavailable Claude 3.7
+    # Sonnet to Claude Sonnet 4.5 (keeps inference profile + KB support).
+    op.execute("""
+        UPDATE public.ai_models
+        SET
+            "name" = 'Claude Sonnet 4.5',
+            provider = 'Anthropic',
+            identifier = 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+            is_default = true,
+            max_input_tokens = 200000,
+            max_output_tokens = 8000,
+            input_modalities = '["Text", "Image"]'::jsonb,
+            output_modalities = '["Text"]'::jsonb,
+            inference = true,
+            supports_knowledge_base = true,
+            category = 'high-end',
+            description = 'Best for document evaluation, complex reasoning, and high-accuracy tasks'
+        WHERE identifier = 'anthropic.claude-3-7-sonnet-20250219-v1:0';
+    """)
+
+
+def downgrade() -> None:
+    # Revert the default Anthropic model back to Claude 3.7 Sonnet.
+    op.execute("""
+        UPDATE public.ai_models
+        SET
+            "name" = 'Claude 3.7 Sonnet',
+            provider = 'Anthropic',
+            identifier = 'anthropic.claude-3-7-sonnet-20250219-v1:0',
+            is_default = true,
+            max_input_tokens = 131000,
+            max_output_tokens = 8000,
+            input_modalities = '["Text", "Image"]'::jsonb,
+            output_modalities = '["Text", "Image"]'::jsonb,
+            inference = true,
+            supports_knowledge_base = true,
+            category = 'high-end',
+            description = 'Budget-friendly models for general chat and lightweight tasks'
+        WHERE identifier = 'anthropic.claude-sonnet-4-5-20250929-v1:0';
+    """)

--- a/alembic/versions/d9be6249c441_add_table_for_service_tokens.py
+++ b/alembic/versions/d9be6249c441_add_table_for_service_tokens.py
@@ -17,7 +17,7 @@
 """Add table for service tokens
 
 Revision ID: d9be6249c441
-Revises: 23817afa2d84
+Revises: 9997efa37f8a
 Create Date: 2025-08-04 12:48:11.928194
 
 """
@@ -29,7 +29,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = 'd9be6249c441'
-down_revision: Union[str, None] = '23817afa2d84'
+down_revision: Union[str, None] = '9997efa37f8a'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/function/llms/bedrock_invoke.py
+++ b/function/llms/bedrock_invoke.py
@@ -181,12 +181,16 @@ def invoke_bedrock_claude(prompt: str, model_id=None):
     system_prompt = "You are an AI assistant focused on clarity, accuracy, and helpfulness."
     max_tokens = model.max_input_tokens if hasattr(model, 'max_input_tokens') else 4096
     
+    # max_tokens in the Claude body is the OUTPUT limit; clamp to the model's output cap
+    # (max_tokens above is the INPUT window, used only for the length guardrail below).
+    max_output_tokens = min(getattr(model, 'max_output_tokens', 8000) or 8000, 8000)
+
     # Guardrail against input tokens overflow
     _check_prompt_length(model_id, prompt, max_tokens)
 
     body = json.dumps({
         "anthropic_version": "bedrock-2023-05-31",
-        "max_tokens": max_tokens,
+        "max_tokens": max_output_tokens,
         "system": system_prompt,
         "messages": [{"role": "user", "content": prompt}],
     })
@@ -234,9 +238,11 @@ def invoke_bedrock_nova(prompt: str, model_id=None):
     body = json.dumps({"schemaVersion": "messages-v1", "messages": messages, "system": system_prompt})
 
     model = get_model_by_id(model_id)
-    max_tokens = model.max_input_tokens if hasattr(model, 'max_input_tokens') else 4096
+    # Output cap (clamped). NOTE: the Nova body above does not currently send a
+    # max-tokens field, so this is informational only — kept correct for consistency.
+    max_output_tokens = min(getattr(model, 'max_output_tokens', 8000) or 8000, 8000)
 
-    # _check_prompt_length(model_id, prompt, max_tokens)
+    # _check_prompt_length(model_id, prompt, max_output_tokens)
 
     if is_inference_model(model_id):
         model_arn = f"arn:aws:bedrock:{region}:{account_id}:inference-profile/{suffix}.{model_id}"
@@ -281,9 +287,12 @@ def invoke_bedrock_meta(prompt: str, model_id=None, temperature=0.7):
         <|start_header_id|>assistant<|end_header_id|>
     """
 
+    # max_gen_len is the OUTPUT length; clamp to the model's output cap rather than the
+    # input window (max_tokens above is the input window, used for the length guardrail).
+    max_output_tokens = min(getattr(model, 'max_output_tokens', 8000) or 8000, 8000)
     body = json.dumps({
         "prompt": formatted_prompt,
-        "max_gen_len": max_tokens,
+        "max_gen_len": max_output_tokens,
         "temperature": temperature,
     })
 
@@ -421,9 +430,11 @@ def retrieve_and_generate(prompt: str, kb_id: str, session_id: str = "", model_i
     citations = response.get("citations", [])
     contexts = [
         {
-            "text": ref["content"]["text"],
-            "document_name": ref["metadata"].get("x-amz-bedrock-kb-source-uri", ""),
-            "page_number": ref["metadata"].get("x-amz-bedrock-kb-document-page-number", ""),
+            # Use .get() — a retrieved reference's content may be byteContent (no "text"
+            # key) rather than plain text, which would otherwise raise KeyError.
+            "text": ref.get("content", {}).get("text", ""),
+            "document_name": ref.get("metadata", {}).get("x-amz-bedrock-kb-source-uri", ""),
+            "page_number": ref.get("metadata", {}).get("x-amz-bedrock-kb-document-page-number", ""),
         }
         for citation in citations
         for ref in citation.get("retrievedReferences", [])

--- a/routers/courses.py
+++ b/routers/courses.py
@@ -18,9 +18,10 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 import os
 import shutil
-from typing import List
+from typing import List, Optional
 from uuid import UUID
 import uuid
+import json
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status, Form, BackgroundTasks
 from fastapi.responses import StreamingResponse
 from requests import Session
@@ -991,9 +992,10 @@ async def get_course_data(
 
 @router.post("/generate-course/", status_code=status.HTTP_202_ACCEPTED)
 async def generate_course(
-    course_id: UUID,
     extra_processing: bool = Form(...),
     files: List[UploadFile] = File(...),
+    title: str = Form(...),
+    settings: Optional[str] = Form(None),
     db: Session = Depends(get_db),
     token: JWTLectureTokenPayload = Depends(require_token_types(allowed_types=["cognito"]))
 ):
@@ -1006,17 +1008,27 @@ async def generate_course(
     4. Ingestion of data
     5. Analysis of the knowledge base
     """
-    course = get_course(db, course_id)
-    if not course:
-        raise HTTPException(status_code=404, detail=COURSE_NOT_FOUND_MESSAGE)
-
     user_id = token.sub
     teacher = get_user_by_cognito_id(db, user_id)
     if not teacher:
         raise HTTPException(status_code=404, detail=TEACHER_NOT_FOUND_MESSAGE)
 
-    if teacher.role not in [UserRole.teacher, UserRole.admin] or course.teacher_id != teacher.id:
+    if teacher.role not in [UserRole.teacher, UserRole.admin]:
         raise HTTPException(status_code=403, detail="Not authorized to generate course")
+
+    # Create the course server-side from the submitted title/settings. The client no
+    # longer pre-creates a course and passes a course_id (matches lecture-backend).
+    settings = json.loads(settings) if settings else {}
+    course_id = uuid.uuid4()
+    course = Course(
+        id=course_id,
+        title=title,
+        description=None,
+        teacher_id=teacher.id,
+        settings=settings if settings else None
+    )
+    db.add(course)
+    db.commit()
 
     # Get the information of the group and region before starting the async process
     user_group = teacher.group
@@ -1129,10 +1141,17 @@ async def process_course_generation(
             priority="normal"
         )
 
+        # The CreateKnowledgeBaseInfrastructure state machine requires a chunking_config
+        # field in its input (the CreateBedrockKnowledgeBase state reads $.chunking_config).
+        # Default to {} when the client didn't specify one, matching lecture-backend.
+        chunking_config = {}
+        if isinstance(course.settings, dict):
+            chunking_config = course.settings.get("chunking_config", {}) or {}
         input_data = {
             "course_id": str(course_id),
             "region_name": region_name,
-            "region_bucket": region_bucket
+            "region_bucket": region_bucket,
+            "chunking_config": chunking_config
         }
         response = start_step_function(input_data)
         execution_arn = response.get("executionArn")

--- a/tests/unit/function/llms/test_bedrock_invoke.py
+++ b/tests/unit/function/llms/test_bedrock_invoke.py
@@ -241,7 +241,7 @@ class TestInvokeBedrockClaude:
             'modelId': f"arn:aws:bedrock:us-east-1::foundation-model/{model_id}",
             'body': json.dumps({
                 "anthropic_version": "bedrock-2023-05-31",
-                "max_tokens": 4096,
+                "max_tokens": 8000,
                 "system": "You are an AI assistant focused on clarity, accuracy, and helpfulness.",
                 "messages": [{"role": "user", "content": "What is the capital of France?"}]
             })
@@ -264,7 +264,7 @@ class TestInvokeBedrockClaude:
             'modelId': f"arn:aws:bedrock:us-east-1::foundation-model/{model_id}",
             'body': json.dumps({
                 "anthropic_version": "bedrock-2023-05-31",
-                "max_tokens": 4096,
+                "max_tokens": 8000,
                 "system": "You are an AI assistant focused on clarity, accuracy, and helpfulness.",
                 "messages": [{"role": "user", "content": "What is the capital of France?"}]
             })
@@ -290,7 +290,7 @@ class TestInvokeBedrockClaude:
             'modelId': f"arn:aws:bedrock:us-east-1::foundation-model/{model_id}",
             'body': json.dumps({
                 "anthropic_version": "bedrock-2023-05-31",
-                "max_tokens": 4096,
+                "max_tokens": 8000,
                 "system": "You are an AI assistant focused on clarity, accuracy, and helpfulness.",
                 "messages": [{"role": "user", "content": "Test prompt"}]
             })
@@ -421,7 +421,7 @@ class TestInvokeBedrockMeta:
         <|eot_id|>
         <|start_header_id|>assistant<|end_header_id|>
     """,
-                "max_gen_len": 4096,
+                "max_gen_len": 8000,
                 "temperature": 0.7
             })
         }
@@ -457,7 +457,7 @@ class TestInvokeBedrockMeta:
         <|eot_id|>
         <|start_header_id|>assistant<|end_header_id|>
     """,
-                "max_gen_len": 4096,
+                "max_gen_len": 8000,
                 "temperature": 0.7
             })
         }

--- a/utility/aws.py
+++ b/utility/aws.py
@@ -292,7 +292,7 @@ def send_invite_email(email: str, invite_url: str, course_name: str) -> None:
 @RetryWithExponentialBackoff(max_retries=5, initial_delay=1, max_delay=32)
 async def generate_course_summary(db: Session, course_id: str, knowledge_base_id: str):
     try:
-        model_id='anthropic.claude-3-7-sonnet-20250219-v1:0'
+        model_id='anthropic.claude-sonnet-4-5-20250929-v1:0'
         prompt="""Human: You are a teacher writing a course description, and output it between the <summary_output> tags.
         
         Based on the search results provided, generate a concise summary of the course materials based on the following instructions:
@@ -350,7 +350,7 @@ async def generate_course_summary(db: Session, course_id: str, knowledge_base_id
 @RetryWithExponentialBackoff(max_retries=5, initial_delay=1, max_delay=32)
 async def generate_course_questions(db: Session, course_id: str, knowledge_base_id: str):
     try:
-        model_id='anthropic.claude-3-7-sonnet-20250219-v1:0'
+        model_id='anthropic.claude-sonnet-4-5-20250929-v1:0'
         prompt = """Human: You are a teacher writing questions for a course, and output them between the <questions_output> tags.
         
         Based on the search results provided, generate 5 questions based on the following instructions:

--- a/utility/chatbot_processor.py
+++ b/utility/chatbot_processor.py
@@ -666,7 +666,7 @@ class ChatbotProcessor:
         Returns:
             Dict[str, Any]: Result of the retrieval
         """
-        model_name = "anthropic.claude-3-7-sonnet-20250219-v1:0"
+        model_name = "anthropic.claude-sonnet-4-5-20250929-v1:0"
         
         try:
             error_message = ""

--- a/utility/pdf_processor.py
+++ b/utility/pdf_processor.py
@@ -433,6 +433,10 @@ class PDFDocumentProcessor:
             
             file_temporary_path = f"{self.material_uuid}.md"
             file_temporary_path_metadata = f"{file_temporary_path}.metadata.json"
+            # The Bedrock KB metadata sidecar is optional: only write/upload/remove it
+            # when there are metadata attributes (otherwise the file is never created and
+            # the unconditional upload/remove below would raise FileNotFoundError).
+            s3_uri_metadata = None
             if metadata:
                 metadata_content = json.dumps({
                     "metadataAttributes": metadata
@@ -441,14 +445,16 @@ class PDFDocumentProcessor:
                     f.write(metadata_content)
             with open(file_temporary_path, "w", encoding='utf-8') as f:
                 f.write(json.dumps(self.data["markdown_content"], ensure_ascii=False))
-            
+
             # Upload both files to S3
             s3_uri = await upload_file_to_s3('content', file_temporary_path, f"{s3_path}/{file_temporary_path}")
-            s3_uri_metadata = await upload_file_to_s3('content', file_temporary_path_metadata, f"{s3_path}/{file_temporary_path_metadata}")
-            
+            if metadata:
+                s3_uri_metadata = await upload_file_to_s3('content', file_temporary_path_metadata, f"{s3_path}/{file_temporary_path_metadata}")
+
             # Clean temporary file
             os.remove(file_temporary_path)
-            os.remove(file_temporary_path_metadata)
+            if metadata:
+                os.remove(file_temporary_path_metadata)
             
             return {
                 "status": "success",


### PR DESCRIPTION
## Summary
Restores knowledge-base creation, the chatbot, and the rich-text AI editor, which broke at runtime because the open-source snapshot (frozen Jan 2026) missed ~5 months of upstream fixes.

- **Model availability**: `claude-3-7-sonnet` no longer has an inference profile in the deployment region (`ResourceNotFoundException`) → repoint the default + hardcoded references to `claude-sonnet-4-5` (new migration + chatbot KB-retrieval + course summary/questions).
- **Alembic**: bridge an orphaned `down_revision` that pointed at a migration dropped during open-sourcing, so `alembic upgrade head` runs again.
- **Bedrock invoke**: send the clamped `max_output_tokens` as the Claude/Meta output limit instead of `max_input_tokens` (was tripping *"Input is too long for requested model"*); parse citation content with `.get()` so non-text (`byteContent`) references no longer `KeyError`.
- **Course generation**: `generate_course` now takes `title`/`settings` and creates the course server-side to match the client (the old `course_id`-required signature returned **422**); `process_course_generation` includes `chunking_config` in the state-machine input (`CreateKnowledgeBaseInfrastructure` requires `$.chunking_config`).
- **PDF processor**: only upload/remove the `.md.metadata.json` sidecar when it was actually written (no filter structure → empty metadata → `FileNotFoundError`). *(latent in upstream too)*

## Test Plan
Verified end-to-end against a dev environment (the unit suite imports live AWS and has pre-existing failures, so it was not used):
- [x] `alembic upgrade head` succeeds; default `ai_models` row = `claude-sonnet-4-5`
- [x] Chatbot KB conversation returns a grounded answer with citations (HTTP 200)
- [x] `/process_text` returns a result (no `ValidationException`)
- [x] Create-KB flow: course created → materials uploaded → state machine `SUCCEEDED` → ingestion `COMPLETE` (2/2 docs) → KB queryable with citations
- [ ] Reviewer: sanity-check against a real deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)